### PR TITLE
Fix Polish dialogue translations and language tags

### DIFF
--- a/ROT-Core/ModuleData/Dialogues/text.xml
+++ b/ROT-Core/ModuleData/Dialogues/text.xml
@@ -1,10 +1,10 @@
 <DialogueLines>
 	<Conversation id="maester_poppy_talk" heroID="" characterID="septon">
-                <DialogueLine nextPage="ask" text="{=ROTUAJijGu0}Czy możesz sprzedać mi mleko makowe, mój dobry maesterze?" isPlayerLine="true" conditionDelegate="MarkPycelleMet" />
-                <DialogueLine page="ask" nextPage="buy" text="{=ROTNeSXldoW}Mam tylko najlepsze, godne królów; nie będzie tanie." />
-                <DialogueLine page="buy" nextPage="thank_you" text="{=ROTsFRq8DTo}Oczywiście, pokaż mi co masz." isPlayerLine="true" consequenceDelegate="BuyPoppy" />
-                <DialogueLine page="buy" nextPage="come_back_soon" text="{=ROTA7g9Gh4p}Przykro mi, maesterze, brakuje mi trochę pieniędzy." isPlayerLine="true" />
-                <DialogueLine page="thank_you" nextPage="end" text="{=ROTwEip3J5U}Dziękuję." />
-                <DialogueLine page="come_back_soon" nextPage="end" text="{=ROTtMWJRuXu}Jeszcze wrócisz." />
-        </Conversation>
+		<DialogueLine nextPage="ask" text="{=ROTUAJijGu0}Can you sell me milk of the poppy my good maester?" isPlayerLine="true" conditionDelegate="MarkPycelleMet" />
+		<DialogueLine page="ask" nextPage="buy" text="{=ROTNeSXldoW}I only have the best, fit for kings; it will not come cheap." />
+		<DialogueLine page="buy" nextPage="thank_you" text="{=ROTsFRq8DTo}Sure, show me what you have." isPlayerLine="true" consequenceDelegate="BuyPoppy" />
+		<DialogueLine page="buy" nextPage="come_back_soon" text="{=ROTA7g9Gh4p}I'm sorry maester, I am running a little short." isPlayerLine="true" />
+		<DialogueLine page="thank_you" nextPage="end" text="{=ROTwEip3J5U}Thank you." />
+		<DialogueLine page="come_back_soon" nextPage="end" text="{=ROTtMWJRuXu}You'll be back." />
+	</Conversation>
 </DialogueLines>

--- a/ROT-Core/ModuleData/Languages/PL/str_polish.xml
+++ b/ROT-Core/ModuleData/Languages/PL/str_polish.xml
@@ -7,6 +7,12 @@
         <tag language="pol"/>
     </tags>
     <strings>
+        <string id="ROTUAJijGu0" text="Czy możesz sprzedać mi mleko makowe, mój dobry maesterze?"/>
+        <string id="ROTNeSXldoW" text="Mam tylko najlepsze, godne królów; nie będzie tanie."/>
+        <string id="ROTsFRq8DTo" text="Oczywiście, pokaż mi co masz."/>
+        <string id="ROTA7g9Gh4p" text="Przykro mi, maesterze, brakuje mi trochę pieniędzy."/>
+        <string id="ROTwEip3J5U" text="Dziękuję."/>
+        <string id="ROTtMWJRuXu" text="Jeszcze wrócisz."/>
         <string id="WBl5hS0e" text="Yohn Royce, znany jako „Brązowy” Yohn, jest władcą Runestone i szefem starszego oddziału House Royce.Lord Royce jest słynnym rycerzem turnieju, który podczas rywalizacji zakłada zestaw brązowej zbroi.Mówi się, że zbroja ma tysiące lat, a jej wpisane runy mogą rzekomo odeprzeć właściciela od szkody."/>
         <string id="ROT8ced0714d" text="Lady Royce z Runestone, żona Lorda Yohna Royce'a."/>
         <string id="ROT868b5cbcd" text="Lord Nestor Royce jest starszym członkiem oddziału kadetów Royce i opiekunem bram Księżyca.Jest kuzynem Pana Yohna Royce'a i jest wdowcem.Przez czternaście lat służył jako wysoki steward doliny."/>


### PR DESCRIPTION
## Summary
- keep English fallback text for maester poppy dialogue
- add Polish translations for those lines to `str_polish.xml`

## Testing
- `xmllint --noout ROT-Core/ModuleData/Languages/PL/str_polish.xml`
- `xmllint --noout ROT-Core/ModuleData/Languages/PL/language_data.xml`
- `xmllint --noout ROT-Core/ModuleData/Dialogues/text.xml`


------
https://chatgpt.com/codex/tasks/task_e_68bb22ba6ecc83208be2c467fbc66d8c